### PR TITLE
fix convnext to make it work with jax.jit

### DIFF
--- a/jax_models/models/convnext.py
+++ b/jax_models/models/convnext.py
@@ -112,7 +112,7 @@ class ConvNeXt(nn.Module):
             "deterministic", self.deterministic, deterministic
         )
 
-        dp_rates = [x.item() for x in jnp.linspace(0, self.drop_path, sum(self.depths))]
+        dp_rates = jnp.linspace(0, self.drop_path, sum(self.depths))
         curr = 0
 
         # Stem


### PR DESCRIPTION
Hey, 
first of all, thanks for the nice codebase. When doing inference using the convnext model, I noticed the following issue:

Calling x.item() will call float(x), which breaks the jit tracer. We can remove the list comprehension in unnecessary conversion to make `jax.jit` work. Without `jax.jit`, the model is very slow for me, running with only  ~30% GPU utilization (RTX 3090).

This issue could apply to other models as well, maybe it is a good idea to include a test for applying `jax.jit` to each model?